### PR TITLE
Support composer/installers 2.x, in addition to the 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
 		"source": "https://github.com/cedaro/dequeue-jquery-migrate"
 	},
 	"require": {
-		"composer/installers": "~1.0"
+		"composer/installers": "~1.0 || ^2.0"
 	}
 }


### PR DESCRIPTION
There are no WordPress-related breaking changes in 2.0, per [the changelog](https://github.com/composer/installers/releases/tag/v2.0.0).

The small code snippet just works otherwise